### PR TITLE
Fix MCP SDK API compatibility issue

### DIFF
--- a/mcp_time_precision/server.py
+++ b/mcp_time_precision/server.py
@@ -163,10 +163,16 @@ class TimePrecisionServer:
         async with stdio_server() as (read_stream, write_stream):
             logger.info(f"Time Precision Server running (Instance: {self.instance_id})")
             
+            # Create capabilities with required parameters for new MCP SDK
+            capabilities = self.server.get_capabilities(
+                notification_options=None,
+                experimental_capabilities={}
+            )
+            
             initialization_options = InitializationOptions(
                 server_name="time-precision",
                 server_version="0.1.0",
-                capabilities=self.server.get_capabilities()
+                capabilities=capabilities
             )
             
             await self.server.run(


### PR DESCRIPTION
## Summary

This PR fixes a compatibility issue with the latest MCP SDK. The `get_capabilities()` method now requires two additional parameters that were missing in our implementation.

## Changes Made

- Updated `server.py` to call `get_capabilities()` with the required parameters:
  - `notification_options=None`
  - `experimental_capabilities={}`

## Error Fixed

```
TypeError: Server.get_capabilities() missing 2 required positional arguments: 'notification_options' and 'experimental_capabilities'
```

## Testing

After this change, the MCP Time Precision server should start successfully without throwing the TypeError.

Fixes the server startup issue reported in the logs from June 20, 2025.